### PR TITLE
OpenAPI: add support for standard annotations

### DIFF
--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -378,6 +378,12 @@ func writeObject(name string, obj *openapi3.SchemaRef, objType openapi3.Types, u
 			break
 		}
 
+		if field.Name == "annotations" {
+			// Standard annotations implementation
+			field.Type = "KeyValueAnnotations"
+			break
+		}
+
 		if obj.Value.AdditionalProperties.Schema != nil && obj.Value.AdditionalProperties.Schema.Value.Type.Is("string") {
 			// AdditionalProperties with type string is a string -> string map
 			field.Type = "KeyValuePairs"


### PR DESCRIPTION
Use `KeyValueAnnotations` for the default annotations field.

Without this, the compiler exits with the error `Please use type KeyValueAnnotations for field annotations`.